### PR TITLE
Fix support for Django native email and add tracking console backend

### DIFF
--- a/emark/migrations/0001_initial.py
+++ b/emark/migrations/0001_initial.py
@@ -39,7 +39,7 @@ class Migration(migrations.Migration):
                 ("to_address", models.EmailField(max_length=254)),
                 ("subject", models.TextField(max_length=998)),
                 ("body", models.TextField()),
-                ("html", models.TextField()),
+                ("html", models.TextField(null=True)),
                 ("utm", models.JSONField(default=dict)),
                 ("created_at", models.DateTimeField(auto_now_add=True)),
             ],

--- a/emark/models.py
+++ b/emark/models.py
@@ -22,7 +22,7 @@ class Send(models.Model):
     to_address = models.EmailField()
     subject = models.TextField(max_length=998)  # RFC 2822
     body = models.TextField()
-    html = models.TextField()
+    html = models.TextField(null=True)
     utm = models.JSONField(default=dict)
     created_at = models.DateTimeField(auto_now_add=True)
 

--- a/emark/views.py
+++ b/emark/views.py
@@ -24,8 +24,12 @@ class EmailDetailView(SingleObjectMixin, View):
 
     def get(self, request, *args, **kwargs):
         self.object = self.get_object()
+        if self.object.html:
+            return http.HttpResponse(
+                self.object.html.encode(), status=200, content_type="text/html"
+            )
         return http.HttpResponse(
-            self.object.html.encode(), status=200, content_type="text/html"
+            self.object.body.encode(), status=200, content_type="text/plain"
         )
 
 

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -14,6 +14,14 @@ class TestEmailDetailView:
         msg = baker.make("emark.Send")
         response = client.get(msg.get_absolute_url())
         assert response.status_code == 200
+        assert response.content == msg.body.encode("utf-8")
+        assert response["Content-Type"] == "text/plain"
+
+    @pytest.mark.django_db
+    def test_get__html(self, client):
+        msg = baker.make("emark.Send", html="<html></html>")
+        response = client.get(msg.get_absolute_url())
+        assert response.status_code == 200
         assert response.content == msg.html.encode("utf-8")
         assert response["Content-Type"] == "text/html"
 


### PR DESCRIPTION
The new tracking backend didn't work for Django's native email messages but only the Emark once.

I also added a console backend that includes all tracking to have a consistent behavior in development and to be able to view HTML template rendering in a browser.