### PR TITLE
Do not track external clicks

### DIFF
--- a/emark/message.py
+++ b/emark/message.py
@@ -117,8 +117,13 @@ class MarkdownEmail(EmailMultiAlternatives):
         redirect_url = parse.urlunparse(redirect_url_parts)
         if not self.uuid:
             return redirect_url
+        site_url = self.get_site_url()
+        # external links should not be tracked
+        top_level_domain = ".".join(site_url.split(".")[-2:])
+        if not redirect_url_parts.netloc.endswith(top_level_domain):
+            return redirect_url
         tracking_url = reverse("emark:email-click", kwargs={"pk": self.uuid})
-        tracking_url = parse.urljoin(self.get_site_url(), tracking_url)
+        tracking_url = parse.urljoin(site_url, tracking_url)
         tracking_url_parts = parse.urlparse(tracking_url)
         tracking_url_parts = tracking_url_parts._replace(
             query=parse.urlencode({"url": redirect_url})

--- a/tests/test_message.py
+++ b/tests/test_message.py
@@ -295,6 +295,17 @@ class TestMarkdownEmail:
             "click?url=https%3A%2F%2Fwww.example.com%2F%3Futm_medium%3Dbaz%26utm_source%3Dfoo"
         )
 
+    def test_update_url_params__subdomain(self, email_message):
+        email_message.uuid = "12341234-1234-1234-1234-123412341234"
+        assert (
+            email_message.update_url_params(
+                "https://test.example.com/?utm_source=foo",
+                utm_medium="baz",
+            )
+            == "http://www.example.com/emark/12341234-1234-1234-1234-123412341234/"
+            "click?url=https%3A%2F%2Ftest.example.com%2F%3Futm_medium%3Dbaz%26utm_source%3Dfoo"
+        )
+
     def test_update_url_params__external_resource(self, email_message):
         email_message._tracking_uuid = "12341234-1234-1234-1234-123412341234"
         assert (

--- a/tests/test_message.py
+++ b/tests/test_message.py
@@ -288,10 +288,21 @@ class TestMarkdownEmail:
         email_message.uuid = "12341234-1234-1234-1234-123412341234"
         assert (
             email_message.update_url_params(
-                "https://localhost:8080/?utm_source=foo",
+                "https://www.example.com/?utm_source=foo",
                 utm_medium="baz",
             )
-            == "http://www.example.com/emark/12341234-1234-1234-1234-123412341234/click?url=https%3A%2F%2Flocalhost%3A8080%2F%3Futm_medium%3Dbaz%26utm_source%3Dfoo"
+            == "http://www.example.com/emark/12341234-1234-1234-1234-123412341234/"
+            "click?url=https%3A%2F%2Fwww.example.com%2F%3Futm_medium%3Dbaz%26utm_source%3Dfoo"
+        )
+
+    def test_update_url_params__external_resource(self, email_message):
+        email_message._tracking_uuid = "12341234-1234-1234-1234-123412341234"
+        assert (
+            email_message.update_url_params(
+                "https://google.com/",
+                utm_medium="baz",
+            )
+            == "https://google.com/?utm_medium=baz"
         )
 
     @pytest.mark.django_db


### PR DESCRIPTION
Wrapping external links is not making sense as tracking view does not allow that and fails with HTTP 400 (`Missing url or malformed parameter`)