### PR TITLE
Increase cssutils logging level to ERROR

### DIFF
--- a/emark/message.py
+++ b/emark/message.py
@@ -226,7 +226,7 @@ class MarkdownEmail(EmailMultiAlternatives):
             html=rendered_html,
             strip_important=False,
             keep_style_tags=True,
-            cssutils_logging_level=logging.WARNING,
+            cssutils_logging_level=logging.ERROR,
         )
         return inlined_html
 


### PR DESCRIPTION
[cssutils is doing some shady things to the logger singleton](https://github.com/jaraco/cssutils/issues/13), that is why it cannot be properly controlled via Django logger (yet).

Thus, I am increasing the current level to `ERROR` until the issue is resolved.