### PR TITLE
Publish to PyPI via Trusted Publisher

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,20 +3,36 @@ name: Release
 on:
   release:
     types: [published]
+  workflow_dispatch:
+
+permissions:
+  id-token: write
 
 jobs:
-  PyPi:
 
+  release-build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
-    - run: sudo apt install -y gettext
-    - uses: actions/setup-python@v5
-      with:
-        python-version: "3.x"
-    - run: python -m pip install --upgrade pip build wheel twine
-    - run: python -m build --sdist --wheel
-    - run: python -m twine upload dist/*
-      env:
-        TWINE_USERNAME: __token__
-        TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+      - run: python -m pip install --upgrade pip build wheel
+      - run: python -m build --sdist --wheel
+      - uses: actions/upload-artifact@v4
+        with:
+          name: release-dists
+          path: dist/
+
+  pypi-publish:
+    runs-on: ubuntu-latest
+    needs:
+      - release-build
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: release-dists
+          path: dist/
+      - uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/about-security-hardening-with-openid-connect