### PR TITLE
Bump Python & Django versions support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,10 +52,10 @@ jobs:
         python-version:
           - "3.10"
           - "3.11"
+          - "3.12"
         django-version:
-          - "3.2"  # LTS
-          - "4.1"
           - "4.2"  # LTS
+          - "5.0"
         extras:
           - "test"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,10 +30,10 @@ classifiers = [
   "Programming Language :: Python :: 3 :: Only",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
   "Framework :: Django",
-  "Framework :: Django :: 3.2",
-  "Framework :: Django :: 4.1",
   "Framework :: Django :: 4.2",
+  "Framework :: Django :: 5.0",
 ]
 requires-python = ">=3.10"
 dependencies = ["django", "markdown", "premailer"]

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,4 +1,0 @@
-[flake8]
-max-line-length=88
-select = C,E,F,W,B,B950
-ignore = E203, E501, W503, E731


### PR DESCRIPTION
Support only actual Python and Django versions:
- Python 3.10, 3.11, 3.12
- Django 4.2 (LTS), 5.0

Refs:
- https://endoflife.date/python
- https://endoflife.date/django

Also, remove obsolete flake8 config (refs e586a62ce9eed3357c93601df17e6ffa43e96797)