### PR TITLE
Apply UTM injection only to http(s) links

### DIFF
--- a/emark/message.py
+++ b/emark/message.py
@@ -17,8 +17,8 @@ from django.utils.safestring import mark_safe
 
 from emark import conf, utils
 
-INLINE_LINK_RE = re.compile(r"\[[^\]]+\]\(([^)]+)\)")
-INLINE_HTML_LINK_RE = re.compile(r"href=\"([^\"]+)\"")
+INLINE_LINK_RE = re.compile(r"\[[^\]]+\]\((https?://[^)]+)\)")
+INLINE_HTML_LINK_RE = re.compile(r'href="https?://([^"]+)"')
 CLS_NAME_TO_CAMPAIGN_RE = re.compile(
     r".+?(?:(?<=[a-z])(?=[A-Z])|(?<=[A-Z])(?=[A-Z][a-z])|$)"
 )

--- a/tests/test_message.py
+++ b/tests/test_message.py
@@ -258,7 +258,7 @@ class TestMarkdownEmail:
         )
         assert email_message.preheader == "Donuts events are back!"
 
-    def test_set_utm_attributes(self):
+    def test_inject_utm_params(self):
         email_message = MarkdownEmailTestWithSubject(
             language="en-US",
             context={"donut_name": "HoneyNuts", "donut_type": "Honey"},
@@ -272,6 +272,7 @@ class TestMarkdownEmail:
             "This is another link! <https://www.example.com/?utm_source=website&utm_medium=email&utm_campaign=MARKDOWN_EMAIL_TEST_WITH_SUBJECT&foo=bar>"
             in email_message.body
         )
+        assert "555-2368 <tel:5552368>" in email_message.body
 
     def test_get_utm_campaign_name(self):
         assert (

--- a/tests/testapp/templates/template.md
+++ b/tests/testapp/templates/template.md
@@ -11,5 +11,6 @@ Vanilla lollipop biscuit cake marzipan jelly.
 
 [This is a link!](https://www.example.com)
 [This is another link!](https://www.example.com/?foo=bar)
+[555-2368](tel:5552368)
 
 <a href="https://www.example.com/html">An HTML Link</a>


### PR DESCRIPTION
Other URI schemes should not care much about UTM parameters, so they can be excluded.
