### PR TITLE
Refs #93 -- Revert URL regex and validate URLs separately

### DIFF
--- a/emark/message.py
+++ b/emark/message.py
@@ -131,7 +131,7 @@ class MarkdownEmail(EmailMultiAlternatives):
         for url in INLINE_LINK_RE.findall(md):
             try:
                 url_parts = parse.urlparse(url)
-                if url_parts.scheme not in [
+                if url_parts.scheme.lower() not in [
                     "http",
                     "https",
                     "",
@@ -143,7 +143,7 @@ class MarkdownEmail(EmailMultiAlternatives):
         for url in INLINE_HTML_LINK_RE.findall(md):
             try:
                 url_parts = parse.urlparse(url)
-                if url_parts.scheme not in [
+                if url_parts.scheme.lower() not in [
                     "http",
                     "https",
                     "",

--- a/emark/message.py
+++ b/emark/message.py
@@ -131,10 +131,10 @@ class MarkdownEmail(EmailMultiAlternatives):
         for url in INLINE_LINK_RE.findall(md):
             try:
                 url_parts = parse.urlparse(url)
-                if url_parts.scheme and url_parts.scheme not in [
+                if url_parts.scheme not in [
                     "http",
                     "https",
-                    "localhost",
+                    "",
                 ]:
                     continue
             except ValueError:
@@ -143,10 +143,10 @@ class MarkdownEmail(EmailMultiAlternatives):
         for url in INLINE_HTML_LINK_RE.findall(md):
             try:
                 url_parts = parse.urlparse(url)
-                if url_parts.scheme and url_parts.scheme not in [
+                if url_parts.scheme not in [
                     "http",
                     "https",
-                    "localhost",
+                    "",
                 ]:
                     continue
             except ValueError:

--- a/tests/test_message.py
+++ b/tests/test_message.py
@@ -281,7 +281,7 @@ class TestMarkdownEmail:
             in email_message.body
         )
         assert (
-            "localhost:8000 <localhost:8000?utm_source=website&utm_medium=email&utm_campaign=MARKDOWN_EMAIL_TEST_WITH_SUBJECT>"
+            "localhost:8000 <http://localhost:8000?utm_source=website&utm_medium=email&utm_campaign=MARKDOWN_EMAIL_TEST_WITH_SUBJECT>"
             in email_message.body
         )
         assert "555-2368 <tel:5552368>" in email_message.body

--- a/tests/test_message.py
+++ b/tests/test_message.py
@@ -265,11 +265,23 @@ class TestMarkdownEmail:
         )
         email_message.render()
         assert (
-            "This is a link! <https://www.example.com?utm_source=website&utm_medium=email&utm_campaign=MARKDOWN_EMAIL_TEST_WITH_SUBJECT>"
+            "A link <https://www.example.com?utm_source=website&utm_medium=email&utm_campaign=MARKDOWN_EMAIL_TEST_WITH_SUBJECT>"
             in email_message.body
         )
         assert (
-            "This is another link! <https://www.example.com/?utm_source=website&utm_medium=email&utm_campaign=MARKDOWN_EMAIL_TEST_WITH_SUBJECT&foo=bar>"
+            "A link with parameter <https://www.example.com/?utm_source=website&utm_medium=email&utm_campaign=MARKDOWN_EMAIL_TEST_WITH_SUBJECT&foo=bar>"
+            in email_message.body
+        )
+        assert (
+            "A link without a scheme <www.example.com?utm_source=website&utm_medium=email&utm_campaign=MARKDOWN_EMAIL_TEST_WITH_SUBJECT>"
+            in email_message.body
+        )
+        assert (
+            "A link without www <example.com?utm_source=website&utm_medium=email&utm_campaign=MARKDOWN_EMAIL_TEST_WITH_SUBJECT>"
+            in email_message.body
+        )
+        assert (
+            "localhost:8000 <localhost:8000?utm_source=website&utm_medium=email&utm_campaign=MARKDOWN_EMAIL_TEST_WITH_SUBJECT>"
             in email_message.body
         )
         assert "555-2368 <tel:5552368>" in email_message.body

--- a/tests/test_message.py
+++ b/tests/test_message.py
@@ -281,6 +281,10 @@ class TestMarkdownEmail:
             in email_message.body
         )
         assert (
+            "ALL CAPS LINK <http://WWW.EXAMPLE.COM?utm_source=website&utm_medium=email&utm_campaign=MARKDOWN_EMAIL_TEST_WITH_SUBJECT>"
+            in email_message.body
+        )
+        assert (
             "localhost:8000 <http://localhost:8000?utm_source=website&utm_medium=email&utm_campaign=MARKDOWN_EMAIL_TEST_WITH_SUBJECT>"
             in email_message.body
         )

--- a/tests/testapp/templates/template.md
+++ b/tests/testapp/templates/template.md
@@ -13,6 +13,7 @@ Vanilla lollipop biscuit cake marzipan jelly.
 [A link with parameter](https://www.example.com/?foo=bar)
 [A link without a scheme](www.example.com)
 [A link without www](example.com)
+[ALL CAPS LINK](HTTP://WWW.EXAMPLE.COM)
 [localhost:8000](http://localhost:8000)
 [555-2368](tel:5552368)
 

--- a/tests/testapp/templates/template.md
+++ b/tests/testapp/templates/template.md
@@ -13,7 +13,7 @@ Vanilla lollipop biscuit cake marzipan jelly.
 [A link with parameter](https://www.example.com/?foo=bar)
 [A link without a scheme](www.example.com)
 [A link without www](example.com)
-[localhost:8000](localhost:8000)
+[localhost:8000](http://localhost:8000)
 [555-2368](tel:5552368)
 
 <a href="https://www.example.com/html">An HTML Link</a>

--- a/tests/testapp/templates/template.md
+++ b/tests/testapp/templates/template.md
@@ -9,8 +9,11 @@ _Shop: {{ donut_shop }}_
 
 Vanilla lollipop biscuit cake marzipan jelly.
 
-[This is a link!](https://www.example.com)
-[This is another link!](https://www.example.com/?foo=bar)
+[A link](https://www.example.com)
+[A link with parameter](https://www.example.com/?foo=bar)
+[A link without a scheme](www.example.com)
+[A link without www](example.com)
+[localhost:8000](localhost:8000)
 [555-2368](tel:5552368)
 
 <a href="https://www.example.com/html">An HTML Link</a>


### PR DESCRIPTION
My initial regex in #93 is not handling correctly URLs without a scheme/www, so I have no better idea here but:
- parse for everything that seems like a markdown link
- validate URL and scheme and apply things only to places we want