### PR TITLE
Fix #97 -- Properly parse domain names in markdown links

### DIFF
--- a/emark/message.py
+++ b/emark/message.py
@@ -116,7 +116,8 @@ class MarkdownEmail(EmailMultiAlternatives):
             return redirect_url
         site_url = self.get_site_url()
         # external links should not be tracked
-        top_level_domain = ".".join(site_url.split(".")[-2:])
+        top_level_domain = utils.extract_domain(site_url)
+
         if not redirect_url_parts.netloc.endswith(top_level_domain):
             return redirect_url
         tracking_url = reverse("emark:email-click", kwargs={"pk": self.uuid})

--- a/emark/utils.py
+++ b/emark/utils.py
@@ -141,7 +141,10 @@ def extract_domain(url: str) -> str:
     """
     extractor = tldextract.TLDExtract(suffix_list_urls=())
     extracted = extractor(url)
-      if port := parse.urlparse(url).port:
-          return f"{extracted.domain}:{port}"
-      return extracted.domain
-    return extracted.registered_domain
+    if extracted.domain == "localhost":
+        registered_domain = "localhost"
+    else:
+        registered_domain = extracted.registered_domain
+    if port := parse.urlparse(url).port:
+        return f"{registered_domain}:{port}"
+    return registered_domain

--- a/emark/utils.py
+++ b/emark/utils.py
@@ -6,6 +6,10 @@ from html.parser import HTMLParser
 
 __all__ = ["HTML2TextParser"]
 
+from urllib import parse
+
+import tldextract
+
 
 @dataclasses.dataclass
 class Node:
@@ -122,3 +126,23 @@ class HTML2TextParser(HTMLParser):
         # sanitize all wide vertical or horizontal spaces
         text = self.DOUBLE_NEWLINE.sub("\n\n", text.strip())
         return self.DOUBLE_SPACE.sub(" ", text)
+
+
+def extract_domain(url: str) -> str:
+    """Extracts the registered domain from a given URL.
+
+    If the domain is "localhost", it includes the port number in the returned string.
+
+    Args:
+        url (str): The URL from which to extract the domain.
+
+    Returns:
+        str: The registered domain or "localhost" with port if applicable.
+    """
+    extractor = tldextract.TLDExtract(suffix_list_urls=())
+    extracted = extractor(url)
+    if extracted.domain == "localhost":
+        if port := parse.urlparse(url).port:
+            return f"{extracted.domain}:{port}"
+        return extracted.domain
+    return extracted.registered_domain

--- a/emark/utils.py
+++ b/emark/utils.py
@@ -141,8 +141,7 @@ def extract_domain(url: str) -> str:
     """
     extractor = tldextract.TLDExtract(suffix_list_urls=())
     extracted = extractor(url)
-    if extracted.domain == "localhost":
-        if port := parse.urlparse(url).port:
-            return f"{extracted.domain}:{port}"
-        return extracted.domain
+      if port := parse.urlparse(url).port:
+          return f"{extracted.domain}:{port}"
+      return extracted.domain
     return extracted.registered_domain

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ classifiers = [
   "Framework :: Django :: 5.0",
 ]
 requires-python = ">=3.10"
-dependencies = ["django", "markdown", "premailer"]
+dependencies = ["django", "markdown", "premailer", "tldextract"]
 
 [project.optional-dependencies]
 test = [

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -110,3 +110,11 @@ class TestHTML2TextParser:
             "--------------------------------------------------\n"
             "some footer"
         )
+
+
+def test_extract_domain():
+    assert utils.extract_domain("https://example.com") == "example.com"
+    assert utils.extract_domain("https://www.example.com") == "example.com"
+    assert utils.extract_domain("https://www.example.co.uk") == "example.co.uk"
+    assert utils.extract_domain("https://localhost") == "localhost"
+    assert utils.extract_domain("https://localhost:8000") == "localhost:8000"

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -116,5 +116,6 @@ def test_extract_domain():
     assert utils.extract_domain("https://example.com") == "example.com"
     assert utils.extract_domain("https://www.example.com") == "example.com"
     assert utils.extract_domain("https://www.example.co.uk") == "example.co.uk"
+    assert utils.extract_domain("https://www.example.com:1337") == "example.com:1337"
     assert utils.extract_domain("https://localhost") == "localhost"
     assert utils.extract_domain("https://localhost:8000") == "localhost:8000"


### PR DESCRIPTION
The problem is described in #97.

I had to introduce a library - [tldextract](https://github.com/john-kurkowski/tldextract/) to properly parse all varieties of domain names.