### PR TITLE
Add Django 6.1 mailer support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,7 @@ jobs:
           - "4.2" # LTS
           - "5.2" # LTS
           - "6.0"
+          - "6.1"
         extras:
           - "test"
         exclude:
@@ -47,6 +48,11 @@ jobs:
             django-version: "6.0"
           - python-version: "3.11"
             django-version: "6.0"
+          # Django 6.1 requires Python 3.12+
+          - python-version: "3.10"
+            django-version: "6.1"
+          - python-version: "3.11"
+            django-version: "6.1"
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v7

--- a/README.md
+++ b/README.md
@@ -135,7 +135,15 @@ pixel and redirect view. However, it will send a separate email for each
 recipient, which may not be desirable in all cases.
 
 ```python
-# settings.py
+# settings.py (Django 6.1+)
+MAILERS = {
+    "default": {
+        "BACKEND": "emark.backends.TrackingSMTPEmailBackend",
+        "OPTIONS": {"host": "smtp.example.com"},
+    }
+}
+
+# Django 6.0 and earlier
 EMAIL_BACKEND = "emark.backends.TrackingSMTPEmailBackend"
 ```
 
@@ -226,7 +234,14 @@ Pretty HTML emails are great, unless they spam your console during development.
 To prevent this, you can use the `ConsoleEmailBackend`:
 
 ```python
-# settings.py
+# settings.py (Django 6.1+)
+MAILERS = {
+    "default": {
+        "BACKEND": "emark.backends.ConsoleEmailBackend",
+    }
+}
+
+# Django 6.0 and earlier
 EMAIL_BACKEND = "emark.backends.ConsoleEmailBackend"
 ```
 

--- a/README.md
+++ b/README.md
@@ -142,9 +142,6 @@ MAILERS = {
         "OPTIONS": {"host": "smtp.example.com"},
     }
 }
-
-# Django 6.0 and earlier
-EMAIL_BACKEND = "emark.backends.TrackingSMTPEmailBackend"
 ```
 
 Furthermore, you need to add the tracking view to your `urls.py`:
@@ -240,9 +237,6 @@ MAILERS = {
         "BACKEND": "emark.backends.ConsoleEmailBackend",
     }
 }
-
-# Django 6.0 and earlier
-EMAIL_BACKEND = "emark.backends.ConsoleEmailBackend"
 ```
 
 The `ConsoleEmailBackend` will only print the plain text version of the email.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,7 @@ classifiers = [
   "Framework :: Django :: 4.2",
   "Framework :: Django :: 5.2",
   "Framework :: Django :: 6.0",
+  "Framework :: Django :: 6.1",
 ]
 requires-python = ">=3.10"
 dependencies = ["django>=5.2.13", "markdown", "premailer"]

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -39,7 +39,7 @@ class TestConsoleEmailBackend:
 
 class TestSMTPEmailBackend:
     def test_enter(self):
-        with backends.SMTPEmailBackend(host="localhost") as backend:
+        with backends.SMTPEmailBackend(alias="default", host="localhost") as backend:
             assert not backend.connection, "Connection should not be opened"
 
     def test_send(self, email_message):
@@ -47,7 +47,7 @@ class TestSMTPEmailBackend:
             def _send(self, message):
                 return bool(message.html)
 
-        backend = TestBackend(host="localhost", fail_silently=False)
+        backend = TestBackend(alias="default", host="localhost", fail_silently=False)
         backend.connection = Mock()
         assert backend.send_messages([email_message]) == 1
 
@@ -119,7 +119,9 @@ class TestTrackingConsoleEmailBackend:
 
 class TestTrackingSMTPEmailBackend:
     def test_enter(self):
-        with backends.TrackingSMTPEmailBackend(host="localhost") as backend:
+        with backends.TrackingSMTPEmailBackend(
+            alias="default", host="localhost"
+        ) as backend:
             assert not backend.connection, "Connection should not be opened"
 
     @pytest.mark.django_db
@@ -133,7 +135,7 @@ class TestTrackingSMTPEmailBackend:
         class TestBackend(backends.TrackingSMTPEmailBackend):
             connection_class = MagicMock
 
-        backend = TestBackend(host="localhost", fail_silently=False)
+        backend = TestBackend(alias="default", host="localhost", fail_silently=False)
         backend.connection = Mock()
         assert backend.send_messages([email_message]) == 1
         assert backend.connection.sendmail.call_count == 1
@@ -155,7 +157,7 @@ class TestTrackingSMTPEmailBackend:
         class TestBackend(backends.TrackingSMTPEmailBackend):
             connection_class = MagicMock
 
-        backend = TestBackend(host="localhost", fail_silently=False)
+        backend = TestBackend(alias="default", host="localhost", fail_silently=False)
         backend.connection = Mock()
         assert backend.send_messages([email_message]) == 1
         assert backend.connection.sendmail.call_count == 1
@@ -169,7 +171,7 @@ class TestTrackingSMTPEmailBackend:
         class TestBackend(backends.TrackingSMTPEmailBackend):
             connection_class = MagicMock
 
-        backend = TestBackend(host="localhost", fail_silently=False)
+        backend = TestBackend(alias="default", host="localhost", fail_silently=False)
         backend.connection = Mock()
         assert backend.send_messages([email_message]) == 1
         assert backend.connection.sendmail.call_count == 1
@@ -188,7 +190,7 @@ class TestTrackingSMTPEmailBackend:
         class TestBackend(backends.TrackingSMTPEmailBackend):
             connection_class = MagicMock
 
-        backend = TestBackend(host="localhost", fail_silently=False)
+        backend = TestBackend(alias="default", host="localhost", fail_silently=False)
         backend.connection = Mock()
         backend.connection.sendmail.side_effect = smtplib.SMTPException
         with pytest.raises(smtplib.SMTPException):
@@ -207,7 +209,7 @@ class TestTrackingSMTPEmailBackend:
         class TestBackend(backends.TrackingSMTPEmailBackend):
             connection_class = MagicMock
 
-        backend = TestBackend(host="localhost", fail_silently=True)
+        backend = TestBackend(alias="default", host="localhost", fail_silently=True)
         backend.connection = Mock()
         assert backend.send_messages([email_message]) == 1
         assert backend.connection.sendmail.call_count == 1
@@ -226,7 +228,7 @@ class TestTrackingSMTPEmailBackend:
         class TestBackend(backends.TrackingSMTPEmailBackend):
             connection_class = MagicMock
 
-        backend = TestBackend(host="localhost", fail_silently=True)
+        backend = TestBackend(alias="default", host="localhost", fail_silently=True)
         backend.connection = Mock()
         backend.connection.sendmail.side_effect = smtplib.SMTPException
         assert backend.send_messages([email_message]) == 0

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -2,13 +2,24 @@ import io
 import smtplib
 from unittest.mock import MagicMock, Mock
 
+import django
 import pytest
 from django.core.mail import EmailMessage, EmailMultiAlternatives
+from django.test import override_settings
 from emark import backends
 from emark.models import Send
 
 
 class TestConsoleEmailBackend:
+    @pytest.mark.skipif(django.VERSION < (6, 1), reason="MAILERS requires Django 6.1+")
+    @override_settings(
+        MAILERS={
+            "default": {"BACKEND": "emark.backends.ConsoleEmailBackend"},
+        }
+    )
+    def test_mailers(self, email_message):
+        assert email_message.send(using="default") == 1
+
     def test_write_message__single(self):
         msg = EmailMessage(body="foo\nbar")
         with io.StringIO() as stream:

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -39,7 +39,7 @@ class TestConsoleEmailBackend:
 
 class TestSMTPEmailBackend:
     def test_enter(self):
-        with backends.SMTPEmailBackend() as backend:
+        with backends.SMTPEmailBackend(host="localhost") as backend:
             assert not backend.connection, "Connection should not be opened"
 
     def test_send(self, email_message):
@@ -47,7 +47,7 @@ class TestSMTPEmailBackend:
             def _send(self, message):
                 return bool(message.html)
 
-        backend = TestBackend(fail_silently=False)
+        backend = TestBackend(host="localhost", fail_silently=False)
         backend.connection = Mock()
         assert backend.send_messages([email_message]) == 1
 
@@ -119,7 +119,7 @@ class TestTrackingConsoleEmailBackend:
 
 class TestTrackingSMTPEmailBackend:
     def test_enter(self):
-        with backends.TrackingSMTPEmailBackend() as backend:
+        with backends.TrackingSMTPEmailBackend(host="localhost") as backend:
             assert not backend.connection, "Connection should not be opened"
 
     @pytest.mark.django_db
@@ -133,7 +133,7 @@ class TestTrackingSMTPEmailBackend:
         class TestBackend(backends.TrackingSMTPEmailBackend):
             connection_class = MagicMock
 
-        backend = TestBackend(fail_silently=False)
+        backend = TestBackend(host="localhost", fail_silently=False)
         backend.connection = Mock()
         assert backend.send_messages([email_message]) == 1
         assert backend.connection.sendmail.call_count == 1
@@ -155,7 +155,7 @@ class TestTrackingSMTPEmailBackend:
         class TestBackend(backends.TrackingSMTPEmailBackend):
             connection_class = MagicMock
 
-        backend = TestBackend(fail_silently=False)
+        backend = TestBackend(host="localhost", fail_silently=False)
         backend.connection = Mock()
         assert backend.send_messages([email_message]) == 1
         assert backend.connection.sendmail.call_count == 1
@@ -169,7 +169,7 @@ class TestTrackingSMTPEmailBackend:
         class TestBackend(backends.TrackingSMTPEmailBackend):
             connection_class = MagicMock
 
-        backend = TestBackend(fail_silently=False)
+        backend = TestBackend(host="localhost", fail_silently=False)
         backend.connection = Mock()
         assert backend.send_messages([email_message]) == 1
         assert backend.connection.sendmail.call_count == 1
@@ -188,7 +188,7 @@ class TestTrackingSMTPEmailBackend:
         class TestBackend(backends.TrackingSMTPEmailBackend):
             connection_class = MagicMock
 
-        backend = TestBackend(fail_silently=False)
+        backend = TestBackend(host="localhost", fail_silently=False)
         backend.connection = Mock()
         backend.connection.sendmail.side_effect = smtplib.SMTPException
         with pytest.raises(smtplib.SMTPException):
@@ -207,7 +207,7 @@ class TestTrackingSMTPEmailBackend:
         class TestBackend(backends.TrackingSMTPEmailBackend):
             connection_class = MagicMock
 
-        backend = TestBackend(fail_silently=True)
+        backend = TestBackend(host="localhost", fail_silently=True)
         backend.connection = Mock()
         assert backend.send_messages([email_message]) == 1
         assert backend.connection.sendmail.call_count == 1
@@ -226,7 +226,7 @@ class TestTrackingSMTPEmailBackend:
         class TestBackend(backends.TrackingSMTPEmailBackend):
             connection_class = MagicMock
 
-        backend = TestBackend(fail_silently=True)
+        backend = TestBackend(host="localhost", fail_silently=True)
         backend.connection = Mock()
         backend.connection.sendmail.side_effect = smtplib.SMTPException
         assert backend.send_messages([email_message]) == 0

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -2,22 +2,18 @@ import io
 import smtplib
 from unittest.mock import MagicMock, Mock
 
-import django
 import pytest
 from django.core.mail import EmailMessage, EmailMultiAlternatives
-from django.test import override_settings
 from emark import backends
 from emark.models import Send
 
 
 class TestConsoleEmailBackend:
-    @pytest.mark.skipif(django.VERSION < (6, 1), reason="MAILERS requires Django 6.1+")
-    @override_settings(
-        MAILERS={
+    def test_mailers(self, email_message, settings):
+        pytest.importorskip("django", minversion="6.1")
+        settings.MAILERS = {
             "default": {"BACKEND": "emark.backends.ConsoleEmailBackend"},
         }
-    )
-    def test_mailers(self, email_message):
         assert email_message.send(using="default") == 1
 
     def test_write_message__single(self):

--- a/tests/testapp/settings.py
+++ b/tests/testapp/settings.py
@@ -132,14 +132,13 @@ DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
 
 # Email settings
 
-if django.VERSION >= (6, 1):
-    MAILERS = {
-        "default": {
-            "BACKEND": "emark.backends.TrackingSMTPEmailBackend",
-            "OPTIONS": {"host": "localhost"},
-        }
+MAILERS = {
+    "default": {
+        "BACKEND": "emark.backends.TrackingSMTPEmailBackend",
+        "OPTIONS": {"host": "localhost"},
     }
-else:
+}
+if django.VERSION < (6, 1):
     EMAIL_BACKEND = "emark.backends.TrackingSMTPEmailBackend"
 
 EMARK = {"DOMAIN": "www.example.com"}

--- a/tests/testapp/settings.py
+++ b/tests/testapp/settings.py
@@ -11,6 +11,8 @@ https://docs.djangoproject.com/en/4.0/ref/settings/
 
 from pathlib import Path
 
+import django
+
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent
 
@@ -130,6 +132,14 @@ DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
 
 # Email settings
 
-EMAIL_BACKEND = "emark.backends.TrackingSMTPEmailBackend"
+if django.VERSION >= (6, 1):
+    MAILERS = {
+        "default": {
+            "BACKEND": "emark.backends.TrackingSMTPEmailBackend",
+            "OPTIONS": {"host": "localhost"},
+        }
+    }
+else:
+    EMAIL_BACKEND = "emark.backends.TrackingSMTPEmailBackend"
 
 EMARK = {"DOMAIN": "www.example.com"}


### PR DESCRIPTION
With Django 6.1 there is a new setting called `MAILERS` that we can support:

https://docs.djangoproject.com/en/6.1/ref/settings/#std-setting-MAILERS